### PR TITLE
updated with `v4-hooks-public`

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -2,8 +2,11 @@
   path = lib/forge-std
   url = https://github.com/foundry-rs/forge-std
 [submodule "lib/v4-periphery"]
-  path = lib/v4-periphery
-  url = https://github.com/Uniswap/v4-periphery
+	path = lib/v4-periphery
+	url = https://github.com/Uniswap/v4-periphery
 [submodule "lib/solady"]
   path = lib/solady
   url = https://github.com/Vectorized/solady
+[submodule "lib/v4-hooks-public"]
+	path = lib/v4-hooks-public
+	url = https://github.com/Uniswap/v4-hooks-public

--- a/foundry.lock
+++ b/foundry.lock
@@ -1,1 +1,5 @@
-{}
+{
+  "lib/v4-periphery": {
+    "rev": "7ebd04b161745b75ed0c24ba2df3bc7c25f65606"
+  }
+}

--- a/src/InternalSwapPool.sol
+++ b/src/InternalSwapPool.sol
@@ -14,7 +14,7 @@ import {CurrencySettler} from '@uniswap/v4-core/test/utils/CurrencySettler.sol';
 
 import {IPoolManager} from '@uniswap/v4-core/src/interfaces/IPoolManager.sol';
 
-import {BaseHook} from 'v4-periphery/src/utils/BaseHook.sol';
+import {BaseHook} from 'lib/v4-hooks-public/src/base/BaseHook.sol';
 
 
 /**


### PR DESCRIPTION
In the recent update, Uniswap removed `hooks` from `v4-periphery` to `v4-hooks-public`. That's why people are having trouble following your tutorial. I have fixed that problem by installing and importing `v4-hooks-public` in the repository.